### PR TITLE
Change common block to global-options

### DIFF
--- a/JSON/fio-multi-params-test.json
+++ b/JSON/fio-multi-params-test.json
@@ -1,7 +1,7 @@
 {
-    "common": [
+    "global-options": [
 	{
-	    "name": "global",
+	    "name": "common-params",
 	    "params": [
 		{ "arg": "bs", "vals": [ "4k", "8k" ] },
 		{ "arg": "norandommap", "vals":  [ "ON" ] },
@@ -39,19 +39,19 @@
     ],
     "sets": [
 	[
-	    { "common": "global" },
-	    { "common": "crucible-defaults" },
+	    { "include": "common-params" },
+	    { "include": "crucible-defaults" },
 
 	    { "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ] },
 	    { "arg": "ioengine", "vals": [ "sync" ] },
 	    { "arg": "iodepth", "vals": [ "1" ] },
 	    { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
 
-	    { "common": "jobs" }
+	    { "include": "jobs" }
 	],
 	[
-	    { "common": "global" },
-	    { "common": "crucible-defaults" },
+	    { "include": "common-params" },
+	    { "include": "crucible-defaults" },
 
 	    { "arg": "rw", "vals": [ "randrw" ] },
 	    { "arg": "ioengine", "vals": [ "sync" ] },
@@ -61,7 +61,7 @@
 	    { "arg": "rwmixwrite", "vals": [ "40" ] },
 	    { "arg": "percentage_random", "vals": [ "100,80" ] },
 
-	    { "common": "jobs" }
+	    { "include": "jobs" }
 	]
     ]
 }

--- a/JSON/mv-params-input.json
+++ b/JSON/mv-params-input.json
@@ -1,26 +1,28 @@
 {
-    "common":
+    "global-options":
     [
         {
-            "name": "global",
+            "name": "common-params",
             "params":
-            [
-                {
-                    "arg": "bs", "vals": [ "4k", "8k" ]
-                },
-                {
-                    "arg": "rw", "vals": [ "read", "write" ]
-                }
-            ]
+                [
+                    {
+                        "arg": "bs", "vals": [ "4k", "8k" ]
+                    },
+                    {
+                        "arg": "rw", "vals": [ "read", "write" ]
+                    }
+                ]
         }
     ],
     "sets":
-    [
-        {
-            "common": "global"
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        }
-    ]
+        [
+            [
+                {
+                    "include": "common-params"
+                },
+                {
+                    "arg": "ioengine", "vals": [ "sync" ]
+                }
+            ]
+        ]
 }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ When running a benchmark, it is often desirable to run it multiple ways, changin
 Multiplex requires a JSON file with the following format:
 ```
 {
-    "common":
+    "global-options":
     [
         {
-            "name": "global",
+            "name": "common-params",
             "params":
             [
                 {
@@ -32,7 +32,7 @@ Multiplex requires a JSON file with the following format:
     [
     [
         {
-            "common": "global"
+            "include": "common-params"
         },
         {
             "arg": "ioengine", "vals": [ "sync" ]
@@ -42,9 +42,9 @@ Multiplex requires a JSON file with the following format:
 }
 ```
 
-The `common` and the `sets` section are required.
+The `global-options` and the `sets` sections are both required.
 A set of "multi-value parameters" is included in each set.  Each set, combined
-with the multi-value paramters in "common", will be used to expand to a new set
+with the multi-value paramters in "global-options", will be used to expand to a new set
 of single-value parameters to STDOUT, like the sample generated in
 `JSON/bench-params-output.json`:
 ```

--- a/multiplex.py
+++ b/multiplex.py
@@ -16,8 +16,8 @@ class t_global(object):
 def process_options():
     """Process arguments from command line"""
     parser = argparse.ArgumentParser(
-        description = 'Translate a JSON with multi-value parameters into a
-                       JSON with single-value parameters')
+        description = 'Translate a JSON with multi-value parameters into a'
+                      'JSON with single-value parameters')
 
     parser.add_argument('--input',
                         dest = 'input',
@@ -35,15 +35,15 @@ def dump_json(obj, format = 'readable'):
     indentation = None
     sep = ':'
     if format == 'readable':
-        intentation = 4
+        indentation = 4
         sep += ' '
 
     return json.dumps(obj, indent = indentation, separators = (',', sep),
                       sort_keys = True)
 
 
-def handle_common(obj):
-    """Handle common data sets"""
+def handle_global_opts(obj):
+    """Handle global-options data sets"""
     new_obj = copy.deepcopy(obj['sets'])
 
     for sets_idx in range(0, len(new_obj)):
@@ -52,13 +52,13 @@ def handle_common(obj):
             restart = False
             found_match = False
             for mv_param_idx in range(0, len(new_obj[sets_idx])):
-                if 'common' in new_obj[sets_idx][mv_param_idx]:
-                    for common_param_set in obj['common']:
-                        if new_obj[sets_idx][mv_param_idx]['common'] == common_param_set['name']:
+                if 'include' in new_obj[sets_idx][mv_param_idx]:
+                    for global_param_set in obj['global-options']:
+                        if new_obj[sets_idx][mv_param_idx]['include'] == global_param_set['name']:
                             found_match = True
                             del new_obj[sets_idx][mv_param_idx]
-                            for insert_offset in range(0, len(common_param_set['params'])):
-                                new_obj[sets_idx].insert(mv_param_idx + insert_offset, copy.deepcopy(common_param_set['params'][insert_offset]))
+                            for insert_offset in range(0, len(global_param_set['params'])):
+                                new_obj[sets_idx].insert(mv_param_idx + insert_offset, copy.deepcopy(global_param_set['params'][insert_offset]))
                             break
                     if found_match:
                         break
@@ -149,7 +149,7 @@ def main():
         print("ERROR: JSON validation failed for %s using schema %s" % (t_global.args.input, json_schema_file))
         return(3)
 
-    combined_json = handle_common(input_json)
+    combined_json = handle_global_opts(input_json)
     multiplexed_json = multiplex_sets(combined_json)
     finalized_json = convert_vals(multiplexed_json)
 

--- a/schema.json
+++ b/schema.json
@@ -4,92 +4,92 @@
 
     "type": "object",
     "properties": {
-	"common": {
-	    "type": "array",
-	    "minItems": 0,
-	    "uniqueItems": true,
-	    "items": {
-		"type": "object",
-		"properties": {
-		    "name": {
-			"type": "string",
-			"minLength": 1
-		    },
-		    "params": {
-			"type": "array",
-			"minItems": 1,
-			"uniqueItems": true,
-			"items": {
-			    "$ref": "#/definitions/mv_param"
-			}
-		    }
-		},
-		"required": [
-		    "name",
-		    "params"
-		],
-		"additionalProperties": false
-	    }
-	},
-	"sets": {
-	    "type": "array",
-	    "minItems": 1,
-	    "uniqueItems": true,
-	    "items": {
-		"type": "array",
-		"minItems": 1,
-		"uniqeueItems": true,
-		"items": {
-		    "oneOf": [
-			{
-			    "type": "object",
-			    "properties": {
-				"common": {
-				    "type": "string",
-				    "minLength": 1
-				}
-			    },
-			    "required": [
-				"common"
-			    ],
-			    "additionalProperties": false
-			},
-			{
-			    "$ref": "#/definitions/mv_param"
-			}
-		    ]
-		}
-	    }
-	}
+        "global-options": {
+            "type": "array",
+            "minItems": 0,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "params": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                            "$ref": "#/definitions/mv_param"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "params"
+                ],
+                "additionalProperties": false
+            }
+    },
+    "sets": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+            "type": "array",
+            "minItems": 1,
+            "uniqeueItems": true,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "include": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        },
+                        "required": [
+                            "include"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                    "$ref": "#/definitions/mv_param"
+                    }
+                ]
+            }
+        }
+    }
     },
     "required": [
-	"common",
-	"sets"
+        "global-options",
+        "sets"
     ],
     "additionalProperties": false,
     "definitions": {
-	"mv_param": {
-	    "type": "object",
-	    "properties": {
-		"arg": {
-		    "type": "string",
-		    "minLength": 1
-		},
-		"vals": {
-		    "type": "array",
-		    "minItems": 1,
-		    "uniqueItems": true,
-		    "items": {
-			"type": "string",
-			"minLength": 1
-		    }
-		}
-	    },
-	    "required": [
-		"arg",
-		"vals"
-	    ],
-	    "additionalProperties": false
-	}
+        "mv_param": {
+            "type": "object",
+            "properties": {
+                "arg": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "vals": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "required": [
+                "arg",
+                "vals"
+            ],
+            "additionalProperties": false
+        }
     }
 }


### PR DESCRIPTION
Modify the schema to avoid confusion around set names and
included sets.

global-options is the array of sets to define general config or
common parameters to be included in the data sets and compose
the matrix of parameters.

'common' block becomes 'global-options'
'global' block name becomes 'common-params'
'common' set becomes 'include'