### PR TITLE
Add roles to the params set

### DIFF
--- a/JSON/bench-params-output.json
+++ b/JSON/bench-params-output.json
@@ -2,56 +2,68 @@
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "4k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "read"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "4k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "write"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "8k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "read"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "8k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "write"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ]

--- a/JSON/bench-params-output.json
+++ b/JSON/bench-params-output.json
@@ -7,7 +7,7 @@
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "read"
         },
         {
@@ -24,7 +24,7 @@
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "write"
         },
         {
@@ -41,7 +41,7 @@
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "read"
         },
         {
@@ -58,7 +58,7 @@
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "write"
         },
         {

--- a/JSON/fio-multi-params-test.json
+++ b/JSON/fio-multi-params-test.json
@@ -1,139 +1,63 @@
 {
     "global-options": [
-    {
-        "name": "common-params",
-        "params": [
         {
-            "arg": "bs", "vals": [ "4k", "8k" ]
+            "name": "common-params",
+            "params": [
+                { "arg": "bs", "vals": [ "4k", "8k" ] },
+                { "arg": "norandommap", "vals":  [ "ON" ] },
+                { "arg": "time_based", "vals": [ "1" ] },
+                { "arg": "runtime", "vals": [ "120" ] },
+                { "arg": "ramp_time", "vals": [ "5" ] },
+                { "arg": "size", "vals": [ "10g" ] },
+                { "arg": "clocksource", "vals": [ "gettimeofday" ] },
+                { "arg": "filename", "vals": [ "/dev/foobar" ] },
+                { "arg": "direct", "vals": [ "1" ] },
+                { "arg": "sync", "vals": [ "0" ] },
+                { "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ] }
+            ]
         },
         {
-            "arg": "norandommap", "vals":  [ "ON" ]
+            "name": "defaults",
+            "params": [
+                { "arg": "write_hist_log", "vals": ["fio"] },
+                { "arg": "log_hist_msec", "vals": ["10000"] },
+                { "arg": "write_bw_log", "vals": ["fio"] },
+                { "arg": "write_iops_log", "vals": ["fio"] },
+                { "arg": "write_lat_log", "vals": ["fio"] },
+                { "arg": "log_avg_msec", "vals": ["1000"] },
+                { "arg": "log_unix_epoch", "vals": ["1"] },
+                { "arg": "output-format", "vals": ["json"] },
+                { "arg": "output", "vals": ["fio-result.json"] }
+            ]
         },
         {
-            "arg": "time_based", "vals": [ "1" ]
-        },
-        {
-            "arg": "runtime", "vals": [ "120" ]
-        },
-        {
-            "arg": "ramp_time", "vals": [ "5" ]
-        },
-        {
-            "arg": "size", "vals": [ "10g" ]
-        },
-        {
-            "arg": "clocksource", "vals": [ "gettimeofday" ]
-        },
-        {
-            "arg": "filename", "vals": [ "/dev/foobar" ]
-        },
-        {
-            "arg": "direct", "vals": [ "1" ]
-        },
-        {
-            "arg": "sync", "vals": [ "0" ]
-        },
-        {
-            "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ]
+            "name": "jobs",
+            "params": [
+                { "arg": "name", "vals": [ "job1" ] }
+            ]
         }
-        ]
-    },
-    {
-        "name": "crucible-defaults",
-        "params": [
-        {
-            "arg": "write_hist_log", "vals": ["fio"]
-        },
-        {
-            "arg": "log_hist_msec", "vals": ["10000"]
-        },
-        {
-            "arg": "write_bw_log", "vals": ["fio"]
-        },
-        {
-            "arg": "write_iops_log", "vals": ["fio"]
-        },
-        {
-            "arg": "write_lat_log", "vals": ["fio"]
-        },
-        {
-            "arg": "log_avg_msec", "vals": ["1000"]
-        },
-        {
-            "arg": "log_unix_epoch", "vals": ["1"]
-        },
-        {
-            "arg": "output-format", "vals": ["json"]
-        },
-        {
-            "arg": "output", "vals": ["fio-result.json"]
-        }
-        ]
-    },
-    {
-        "name": "jobs",
-        "params": [
-        {
-            "arg": "name", "vals": [ "job1" ]
-        }
-        ]
-    }
     ],
     "sets": [
-    [
-        {
-            "include": "common-params"
-        },
-        {
-            "include": "crucible-defaults"
-        },
-        {
-            "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ]
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        },
-        {
-            "arg": "iodepth", "vals": [ "1" ]
-        },
-        {
-            "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ]
-        },
-        {
-            "include": "jobs"
-        }
-    ],
-    [
-        {
-            "include": "common-params"
-        },
-        {
-            "include": "crucible-defaults"
-        },
-        {
-            "arg": "rw", "vals": [ "randrw" ]
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        },
-        {
-            "arg": "iodepth", "vals": [ "1" ]
-        },
-        {
-            "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ]
-        },
-        {
-            "arg": "rwmixread", "vals": [ "60" ]
-        },
-        {
-            "arg": "rwmixwrite", "vals": [ "40" ]
-        },
-        {
-            "arg": "percentage_random", "vals": [ "100,80" ]
-        },
-        {
-            "include": "jobs"
-        }
-    ]
+        [
+            { "include": "common-params" },
+            { "include": "crucible-defaults" },
+            { "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ] },
+            { "arg": "ioengine", "vals": [ "sync" ] },
+            { "arg": "iodepth", "vals": [ "1" ] },
+            { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
+            { "include": "jobs" }
+        ],
+        [
+            { "include": "common-params" },
+            { "include": "crucible-defaults" },
+            { "arg": "rw", "vals": [ "randrw" ] },
+            { "arg": "ioengine", "vals": [ "sync" ] },
+            { "arg": "iodepth", "vals": [ "1" ] },
+            { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
+            { "arg": "rwmixread", "vals": [ "60" ] },
+            { "arg": "rwmixwrite", "vals": [ "40" ] },
+            { "arg": "percentage_random", "vals": [ "100,80" ] },
+            { "include": "jobs" }
+        ]
     ]
 }

--- a/JSON/fio-multi-params-test.json
+++ b/JSON/fio-multi-params-test.json
@@ -3,61 +3,137 @@
     {
         "name": "common-params",
         "params": [
-        { "arg": "bs", "vals": [ "4k", "8k" ] },
-        { "arg": "norandommap", "vals":  [ "ON" ] },
-        { "arg": "time_based", "vals": [ "1" ] },
-        { "arg": "runtime", "vals": [ "120" ] },
-        { "arg": "ramp_time", "vals": [ "5" ] },
-        { "arg": "size", "vals": [ "10g" ] },
-        { "arg": "clocksource", "vals": [ "gettimeofday" ] },
-        { "arg": "filename", "vals": [ "/dev/foobar" ] },
-        { "arg": "direct", "vals": [ "1" ] },
-        { "arg": "sync", "vals": [ "0" ] },
-        { "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ] }
+        {
+            "arg": "bs", "vals": [ "4k", "8k" ]
+        },
+        {
+            "arg": "norandommap", "vals":  [ "ON" ]
+        },
+        {
+            "arg": "time_based", "vals": [ "1" ]
+        },
+        {
+            "arg": "runtime", "vals": [ "120" ]
+        },
+        {
+            "arg": "ramp_time", "vals": [ "5" ]
+        },
+        {
+            "arg": "size", "vals": [ "10g" ]
+        },
+        {
+            "arg": "clocksource", "vals": [ "gettimeofday" ]
+        },
+        {
+            "arg": "filename", "vals": [ "/dev/foobar" ]
+        },
+        {
+            "arg": "direct", "vals": [ "1" ]
+        },
+        {
+            "arg": "sync", "vals": [ "0" ]
+        },
+        {
+            "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ]
+        }
         ]
     },
     {
         "name": "crucible-defaults",
         "params": [
-        { "arg": "write_hist_log", "vals": ["fio"] },
-        { "arg": "log_hist_msec", "vals": ["10000"] },
-        { "arg": "write_bw_log", "vals": ["fio"] },
-        { "arg": "write_iops_log", "vals": ["fio"] },
-        { "arg": "write_lat_log", "vals": ["fio"] },
-        { "arg": "log_avg_msec", "vals": ["1000"] },
-        { "arg": "log_unix_epoch", "vals": ["1"] },
-        { "arg": "output-format", "vals": ["json"] },
-        { "arg": "output", "vals": ["fio-result.json"] }
+        {
+            "arg": "write_hist_log", "vals": ["fio"]
+        },
+        {
+            "arg": "log_hist_msec", "vals": ["10000"]
+        },
+        {
+            "arg": "write_bw_log", "vals": ["fio"]
+        },
+        {
+            "arg": "write_iops_log", "vals": ["fio"]
+        },
+        {
+            "arg": "write_lat_log", "vals": ["fio"]
+        },
+        {
+            "arg": "log_avg_msec", "vals": ["1000"]
+        },
+        {
+            "arg": "log_unix_epoch", "vals": ["1"]
+        },
+        {
+            "arg": "output-format", "vals": ["json"]
+        },
+        {
+            "arg": "output", "vals": ["fio-result.json"]
+        }
         ]
     },
     {
         "name": "jobs",
         "params": [
-        { "arg": "name", "vals": [ "job1" ] }
+        {
+            "arg": "name", "vals": [ "job1" ]
+        }
         ]
     }
     ],
     "sets": [
     [
-        { "include": "common-params" },
-        { "include": "crucible-defaults" },
-        { "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ] },
-        { "arg": "ioengine", "vals": [ "sync" ] },
-        { "arg": "iodepth", "vals": [ "1" ] },
-        { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
-        { "include": "jobs" }
+        {
+            "include": "common-params"
+        },
+        {
+            "include": "crucible-defaults"
+        },
+        {
+            "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ]
+        },
+        {
+            "arg": "ioengine", "vals": [ "sync" ]
+        },
+        {
+            "arg": "iodepth", "vals": [ "1" ]
+        },
+        {
+            "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ]
+        },
+        {
+            "include": "jobs"
+        }
     ],
     [
-        { "include": "common-params" },
-        { "include": "crucible-defaults" },
-        { "arg": "rw", "vals": [ "randrw" ] },
-        { "arg": "ioengine", "vals": [ "sync" ] },
-        { "arg": "iodepth", "vals": [ "1" ] },
-        { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
-        { "arg": "rwmixread", "vals": [ "60" ] },
-        { "arg": "rwmixwrite", "vals": [ "40" ] },
-        { "arg": "percentage_random", "vals": [ "100,80" ] },
-        { "include": "jobs" }
+        {
+            "include": "common-params"
+        },
+        {
+            "include": "crucible-defaults"
+        },
+        {
+            "arg": "rw", "vals": [ "randrw" ]
+        },
+        {
+            "arg": "ioengine", "vals": [ "sync" ]
+        },
+        {
+            "arg": "iodepth", "vals": [ "1" ]
+        },
+        {
+            "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ]
+        },
+        {
+            "arg": "rwmixread", "vals": [ "60" ]
+        },
+        {
+            "arg": "rwmixwrite", "vals": [ "40" ]
+        },
+        {
+            "arg": "percentage_random", "vals": [ "100,80" ]
+        },
+        {
+            "include": "jobs"
+        }
     ]
     ]
 }

--- a/JSON/fio-multi-params-test.json
+++ b/JSON/fio-multi-params-test.json
@@ -1,67 +1,63 @@
 {
     "global-options": [
-	{
-	    "name": "common-params",
-	    "params": [
-		{ "arg": "bs", "vals": [ "4k", "8k" ] },
-		{ "arg": "norandommap", "vals":  [ "ON" ] },
-		{ "arg": "time_based", "vals": [ "1" ] },
-		{ "arg": "runtime", "vals": [ "120" ] },
-		{ "arg": "ramp_time", "vals": [ "5" ] },
-		{ "arg": "size", "vals": [ "10g" ] },
-		{ "arg": "clocksource", "vals": [ "gettimeofday" ] },
-		{ "arg": "filename", "vals": [ "/dev/foobar" ] },
-		{ "arg": "direct", "vals": [ "1" ] },
-		{ "arg": "sync", "vals": [ "0" ] },
-		{ "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ] }
-	    ]
-	},
-	{
-	    "name": "crucible-defaults",
-	    "params": [
-		{ "arg": "write_hist_log", "vals": ["fio"] },
-		{ "arg": "log_hist_msec", "vals": ["10000"] },
-		{ "arg": "write_bw_log", "vals": ["fio"] },
-		{ "arg": "write_iops_log", "vals": ["fio"] },
-		{ "arg": "write_lat_log", "vals": ["fio"] },
-		{ "arg": "log_avg_msec", "vals": ["1000"] },
-		{ "arg": "log_unix_epoch", "vals": ["1"] },
-		{ "arg": "output-format", "vals": ["json"] },
-		{ "arg": "output", "vals": ["fio-result.json"] }
-	    ]
-	},
-	{
-	    "name": "jobs",
-	    "params": [
-		{ "arg": "name", "vals": [ "job1" ] }
-	    ]
-	}
+    {
+        "name": "common-params",
+        "params": [
+        { "arg": "bs", "vals": [ "4k", "8k" ] },
+        { "arg": "norandommap", "vals":  [ "ON" ] },
+        { "arg": "time_based", "vals": [ "1" ] },
+        { "arg": "runtime", "vals": [ "120" ] },
+        { "arg": "ramp_time", "vals": [ "5" ] },
+        { "arg": "size", "vals": [ "10g" ] },
+        { "arg": "clocksource", "vals": [ "gettimeofday" ] },
+        { "arg": "filename", "vals": [ "/dev/foobar" ] },
+        { "arg": "direct", "vals": [ "1" ] },
+        { "arg": "sync", "vals": [ "0" ] },
+        { "arg": "jobfile", "vals": [ "EMPTY_JOB_FILE" ] }
+        ]
+    },
+    {
+        "name": "crucible-defaults",
+        "params": [
+        { "arg": "write_hist_log", "vals": ["fio"] },
+        { "arg": "log_hist_msec", "vals": ["10000"] },
+        { "arg": "write_bw_log", "vals": ["fio"] },
+        { "arg": "write_iops_log", "vals": ["fio"] },
+        { "arg": "write_lat_log", "vals": ["fio"] },
+        { "arg": "log_avg_msec", "vals": ["1000"] },
+        { "arg": "log_unix_epoch", "vals": ["1"] },
+        { "arg": "output-format", "vals": ["json"] },
+        { "arg": "output", "vals": ["fio-result.json"] }
+        ]
+    },
+    {
+        "name": "jobs",
+        "params": [
+        { "arg": "name", "vals": [ "job1" ] }
+        ]
+    }
     ],
     "sets": [
-	[
-	    { "include": "common-params" },
-	    { "include": "crucible-defaults" },
-
-	    { "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ] },
-	    { "arg": "ioengine", "vals": [ "sync" ] },
-	    { "arg": "iodepth", "vals": [ "1" ] },
-	    { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
-
-	    { "include": "jobs" }
-	],
-	[
-	    { "include": "common-params" },
-	    { "include": "crucible-defaults" },
-
-	    { "arg": "rw", "vals": [ "randrw" ] },
-	    { "arg": "ioengine", "vals": [ "sync" ] },
-	    { "arg": "iodepth", "vals": [ "1" ] },
-	    { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
-	    { "arg": "rwmixread", "vals": [ "60" ] },
-	    { "arg": "rwmixwrite", "vals": [ "40" ] },
-	    { "arg": "percentage_random", "vals": [ "100,80" ] },
-
-	    { "include": "jobs" }
-	]
+    [
+        { "include": "common-params" },
+        { "include": "crucible-defaults" },
+        { "arg": "rw", "vals": [ "read", "write", "randread", "randwrite" ] },
+        { "arg": "ioengine", "vals": [ "sync" ] },
+        { "arg": "iodepth", "vals": [ "1" ] },
+        { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
+        { "include": "jobs" }
+    ],
+    [
+        { "include": "common-params" },
+        { "include": "crucible-defaults" },
+        { "arg": "rw", "vals": [ "randrw" ] },
+        { "arg": "ioengine", "vals": [ "sync" ] },
+        { "arg": "iodepth", "vals": [ "1" ] },
+        { "arg": "numjobs", "vals": [ "1", "4", "8", "12", "16", "20" ] },
+        { "arg": "rwmixread", "vals": [ "60" ] },
+        { "arg": "rwmixwrite", "vals": [ "40" ] },
+        { "arg": "percentage_random", "vals": [ "100,80" ] },
+        { "include": "jobs" }
+    ]
     ]
 }

--- a/JSON/mv-params-input.json
+++ b/JSON/mv-params-input.json
@@ -6,10 +6,10 @@
             "params":
                 [
                     {
-                        "arg": "bs", "vals": [ "4k", "8k" ]
+                        "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
                     },
                     {
-                        "arg": "rw", "vals": [ "read", "write" ]
+                        "arg": "rw", "vals": [ "read", "write" ], "role": "server"
                     }
                 ]
         }

--- a/JSON/mv-params-input.json
+++ b/JSON/mv-params-input.json
@@ -9,7 +9,7 @@
                         "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
                     },
                     {
-                        "arg": "rw", "vals": [ "read", "write" ], "role": "server"
+                        "arg": "rw", "vals": [ "read", "write" ]
                     }
                 ]
         }

--- a/JSON/mv-params-input.json
+++ b/JSON/mv-params-input.json
@@ -1,28 +1,25 @@
 {
-    "global-options":
+    "global-options": [
+    {
+        "name": "common-params",
+        "params": [
+        {
+            "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
+        },
+        {
+            "arg": "rw", "vals": [ "read", "write" ]
+        }
+        ]
+    }
+    ],
+    "sets": [
     [
         {
-            "name": "common-params",
-            "params":
-                [
-                    {
-                        "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
-                    },
-                    {
-                        "arg": "rw", "vals": [ "read", "write" ]
-                    }
-                ]
+            "include": "common-params"
+        },
+        {
+            "arg": "ioengine", "vals": [ "sync" ]
         }
-    ],
-    "sets":
-        [
-            [
-                {
-                    "include": "common-params"
-                },
-                {
-                    "arg": "ioengine", "vals": [ "sync" ]
-                }
-            ]
-        ]
+    ]
+    ]
 }

--- a/JSON/mv-params-input.json
+++ b/JSON/mv-params-input.json
@@ -1,25 +1,17 @@
 {
     "global-options": [
-    {
-        "name": "common-params",
-        "params": [
         {
-            "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
-        },
-        {
-            "arg": "rw", "vals": [ "read", "write" ]
+            "name": "common-params",
+            "params": [
+                { "arg": "bs", "vals": [ "4k", "8k" ], "role": "client" },
+                { "arg": "rw", "vals": [ "read", "write" ] }
+            ]
         }
-        ]
-    }
     ],
     "sets": [
-    [
-        {
-            "include": "common-params"
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        }
-    ]
+        [
+            { "include": "common-params" },
+            { "arg": "ioengine", "vals": [ "sync" ] }
+        ]
     ]
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Multiplex requires a JSON file with the following format:
                         "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
                     },
                     {
-                        "arg": "rw", "vals": [ "read", "write" ], "role": "server"
+                        "arg": "rw", "vals": [ "read", "write" ]
                     }
                 ]
         }
@@ -48,7 +48,7 @@ data can be replicated and included in the `sets` section.
 In this section, you may have an array of multi-value parameters that are common to
 the test run as "common-params". Multi-value params are specified with the `args` and
 `vals` keywords. The `role` key is optional and defaults to 'client' if omitted. Valid
-roles are: "client" and "server".
+roles are: "client", "server" and "all".
 
 Also, you may have a block to define benchmark or tooling specific settings. Example:
 "crucible-defaults".
@@ -60,7 +60,7 @@ A data set of multi-value parameters is defined in each block inside the `sets` 
 The `sets` section is required and must have one or more set(s). Multi-value params are
 specified with the `args` and `vals` keywords, identical to the "common-params" block
 from the `global-options`. Likewise, the `role` key is optional and defaults to 'client'
-if omitted. Valid roles are "client" and "server".
+if omitted. Valid roles are "client", "server" and "all".
 
 
 ## Output single-value JSON
@@ -77,7 +77,7 @@ parameters to STDOUT. A sample is available in `JSON/bench-params-output.json`:
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "read"
         },
         {
@@ -94,7 +94,7 @@ parameters to STDOUT. A sample is available in `JSON/bench-params-output.json`:
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "write"
         },
         {
@@ -111,7 +111,7 @@ parameters to STDOUT. A sample is available in `JSON/bench-params-output.json`:
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "read"
         },
         {
@@ -128,7 +128,7 @@ parameters to STDOUT. A sample is available in `JSON/bench-params-output.json`:
         },
         {
             "arg": "rw",
-            "role": "server",
+            "role": "client",
             "val": "write"
         },
         {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When running a benchmark, it is often desirable to run it multiple ways, changin
 ./multiplex.py --input JSON/mv-params-input.json > /path/to/bench-params.json
 ```
 
-## Input and Output
+## Input multi-value JSON
 Multiplex requires a JSON file with the following format:
 ```
 {
@@ -18,90 +18,122 @@ Multiplex requires a JSON file with the following format:
         {
             "name": "common-params",
             "params":
-            [
-                {
-                    "arg": "bs", "vals": [ "4k", "8k" ]
-                },
-                {
-                    "arg": "rw", "vals": [ "read", "write" ]
-                }
-            ]
+                [
+                    {
+                        "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
+                    },
+                    {
+                        "arg": "rw", "vals": [ "read", "write" ], "role": "server"
+                    }
+                ]
         }
     ],
     "sets":
-    [
-    [
-        {
-            "include": "common-params"
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        }
-    ]
-    ]
+        [
+            [
+                {
+                    "include": "common-params"
+                },
+                {
+                    "arg": "ioengine", "vals": [ "sync" ]
+                }
+            ]
+        ]
 }
 ```
 
-The `global-options` and the `sets` sections are both required.
-A set of "multi-value parameters" is included in each set.  Each set, combined
-with the multi-value paramters in "global-options", will be used to expand to a new set
-of single-value parameters to STDOUT, like the sample generated in
-`JSON/bench-params-output.json`:
+### global-options
+The `global-options` section is required. It contains blocks of general configuration
+data can be replicated and included in the `sets` section.
+In this section, you may have an array of multi-value parameters that are common to
+the test run as "common-params". Multi-value params are specified with the `args` and
+`vals` keywords. The `role` key is optional and defaults to 'client' if omitted. Valid
+roles are: "client" and "server".
+
+Also, you may have a block to define benchmark or tooling specific settings. Example:
+"crucible-defaults".
+
+These blocks must have "name" and "params" key values.
+
+### sets
+A data set of multi-value parameters is defined in each block inside the `sets` section.
+The `sets` section is required and must have one or more set(s). Multi-value params are
+specified with the `args` and `vals` keywords, identical to the "common-params" block
+from the `global-options`. Likewise, the `role` key is optional and defaults to 'client'
+if omitted. Valid roles are "client" and "server".
+
+
+## Output single-value JSON
+Each data set from the `sets` section, combined with the multi-value paramters included
+from the "global-options", are processed and expanded to a new structure of single-value
+parameters to STDOUT. A sample is available in `JSON/bench-params-output.json`:
 ```
 [
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "4k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "read"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "4k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "write"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "8k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "read"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ],
     [
         {
             "arg": "bs",
+            "role": "client",
             "val": "8k"
         },
         {
             "arg": "rw",
+            "role": "server",
             "val": "write"
         },
         {
             "arg": "ioengine",
+            "role": "client",
             "val": "sync"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -14,27 +14,19 @@ Multiplex requires a JSON file with the following format:
 ```
 {
     "global-options": [
-    {
-        "name": "common-params",
-        "params": [
         {
-            "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
-        },
-        {
-            "arg": "rw", "vals": [ "read", "write" ]
+            "name": "common-params",
+            "params": [
+                { "arg": "bs", "vals": [ "4k", "8k" ], "role": "client" },
+                { "arg": "rw", "vals": [ "read", "write" ] }
+            ]
         }
-        ]
-    }
     ],
     "sets": [
-    [
-        {
-            "include": "common-params"
-        },
-        {
-            "arg": "ioengine", "vals": [ "sync" ]
-        }
-    ]
+        [
+            { "include": "common-params" },
+            { "arg": "ioengine", "vals": [ "sync" ] }
+        ]
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,45 +13,39 @@ When running a benchmark, it is often desirable to run it multiple ways, changin
 Multiplex requires a JSON file with the following format:
 ```
 {
-    "global-options":
+    "global-options": [
+    {
+        "name": "common-params",
+        "params": [
+        {
+            "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
+        },
+        {
+            "arg": "rw", "vals": [ "read", "write" ]
+        }
+        ]
+    }
+    ],
+    "sets": [
     [
         {
-            "name": "common-params",
-            "params":
-                [
-                    {
-                        "arg": "bs", "vals": [ "4k", "8k" ], "role": "client"
-                    },
-                    {
-                        "arg": "rw", "vals": [ "read", "write" ]
-                    }
-                ]
+            "include": "common-params"
+        },
+        {
+            "arg": "ioengine", "vals": [ "sync" ]
         }
-    ],
-    "sets":
-        [
-            [
-                {
-                    "include": "common-params"
-                },
-                {
-                    "arg": "ioengine", "vals": [ "sync" ]
-                }
-            ]
-        ]
+    ]
+    ]
 }
 ```
 
 ### global-options
 The `global-options` section is required. It contains blocks of general configuration
-data can be replicated and included in the `sets` section.
+data that can be replicated and included in the `sets` section.
 In this section, you may have an array of multi-value parameters that are common to
-the test run as "common-params". Multi-value params are specified with the `args` and
-`vals` keywords. The `role` key is optional and defaults to 'client' if omitted. Valid
-roles are: "client", "server" and "all".
-
-Also, you may have a block to define benchmark or tooling specific settings. Example:
-"crucible-defaults".
+the test run such as "common-params". Multi-value params are specified with the `args`
+and `vals` keywords. The `role` key is optional and defaults to 'client' if omitted.
+Valid roles are: "client", "server" and "all".
 
 These blocks must have "name" and "params" key values.
 

--- a/multiplex.py
+++ b/multiplex.py
@@ -73,6 +73,10 @@ def multiplex_set(obj):
     new_obj = []
 
     for set_idx in range(0, len(obj)):
+        # default to client role if not specified
+        if "role" not in obj[set_idx]:
+            obj[set_idx]['role'] = "client"
+
         if len(obj[set_idx]['vals']) > 1:
             for copies in range(0, len(obj[set_idx]['vals'])):
                 new_obj.append(copy.deepcopy(obj))

--- a/schema.json
+++ b/schema.json
@@ -83,6 +83,10 @@
                         "type": "string",
                         "minLength": 1
                     }
+                },
+                "role": {
+                    "type": "string",
+                    "enum": ["client", "server"]
                 }
             },
             "required": [

--- a/schema.json
+++ b/schema.json
@@ -86,7 +86,7 @@
                 },
                 "role": {
                     "type": "string",
-                    "enum": ["client", "server"]
+                    "enum": ["client", "server", "all"]
                 }
             },
             "required": [


### PR DESCRIPTION
Introduce functions for each parameter. This change adds an option
to control what tier/role a parameter is intended for. With this
change the parameters will directed to the right place.

This initial implementation starts with client and server roles.
The keyword 'role' is optional and defaults to 'client' if omitted.

Closes #11