### PR TITLE
Fix min params array size

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -46,16 +46,12 @@
                     },
                     "params": {
                         "type": "array",
-                        "minItems": 1,
                         "uniqueItems": true,
                         "items": {
                             "$ref": "#/definitions/mv_param"
                         }
                     }
                 },
-                "required": [
-                    "params"
-                ],
                 "additionalProperties": false
             }
         }


### PR DESCRIPTION
Users now can have:
 - empty params with no elements inside
 - params property to be omitted in the set

This allows including common params and not having to add new
param sets.