### PR TITLE
Fix regression on include common-params

### DIFF
--- a/multiplex.py
+++ b/multiplex.py
@@ -96,7 +96,7 @@ def load_param_sets(sets_block):
                 if set['include'] == global_opt['name']:
                     for global_param in global_opt['params']:
                         if param_enabled(global_param):
-                            param_set.append(global_param)
+                            param_set.append(copy.deepcopy(global_param))
 
         # handle params in each set
         if 'params' in set:

--- a/tests/test-json.py
+++ b/tests/test-json.py
@@ -48,6 +48,33 @@ class TestJSON:
         ]
     }
     """
+    json_multi_params_sets="""
+    {
+        "global-options": [
+            {
+                "name": "common-params",
+                "params": [
+                    { "arg": "rw", "vals": [ "read", "write" ] }
+                ]
+            }
+        ],
+        "sets": [
+            {
+                "include": "common-params",
+                "params": [
+                    { "arg": "ioengine", "vals": [ "sync" ] }
+                ]
+            },
+            {
+                "include": "common-params",
+                "params": [
+                    { "arg": "bs", "vals": [ "4k", "1M" ] }
+                ]
+            }
+        ]
+    }
+    """
+
 
     # This is the output of load_param_sets function and
     # the input for multiplex_sets function
@@ -63,13 +90,34 @@ class TestJSON:
     [{"arg": "rw", "role": "client", "val": "write"}]]
     """
 
+    json_multi_sets_expected="""
+    [[{"arg": "rw", "vals": ["read", "write"]},
+    {"arg": "ioengine", "vals": ["sync"]}],
+    [{"arg": "rw", "vals": ["read", "write"]},
+    {"arg": "bs", "vals": ["4k", "1M"]}]]
+    """
+
+    json_multiplexed_multi_sets_expected="""
+    [[{"arg": "rw", "role": "client", "vals": ["read"]},
+    {"arg": "ioengine", "role": "client", "vals": ["sync"]}],
+    [{"arg": "rw", "role": "client", "vals": ["write"]},
+    {"arg": "ioengine", "role": "client", "vals": ["sync"]}],
+    [{"arg": "rw", "role": "client", "vals": ["read"]},
+    {"arg": "bs", "role": "client", "vals": ["4k"]}],
+    [{"arg": "rw", "role": "client", "vals": ["read"]},
+    {"arg": "bs", "role": "client", "vals": ["1M"]}],
+    [{"arg": "rw", "role": "client", "vals": ["write"]},
+    {"arg": "bs", "role": "client", "vals": ["4k"]}],
+    [{"arg": "rw", "role": "client", "vals": ["write"]},
+    {"arg": "bs", "role": "client", "vals": ["1M"]}]]
+    """
 
     @pytest.fixture(scope="function")
     def load_json(self, request):
         return json.loads(request.param)
 
 
-    """Test if handle_global_opts removes disabled params from global params"""
+    """Test if load_param_sets removes disabled params from global params"""
     @pytest.mark.parametrize("load_json", [ json_disabled_params_global ], indirect=True)
     def test_disabled_global_params(self, load_json):
         combined_json = multiplex.load_param_sets(load_json)
@@ -79,7 +127,7 @@ class TestJSON:
         assert short_json == expected_json
 
 
-    """Test if hanlde_global_opts removes disabled params from global params"""
+    """Test if load_param_sets removes disabled params from global params"""
     @pytest.mark.parametrize("load_json", [ json_disabled_params_sets ], indirect=True)
     def test_disabled_sets_params(self, load_json):
         combined_json = multiplex.load_param_sets(load_json)
@@ -109,3 +157,34 @@ class TestJSON:
 
         assert short_json.replace(" ", "") == expected_json.replace(" ", "")
 
+    """Test if load_param_sets handles multiple sets of params"""
+    @pytest.mark.parametrize("load_json", [ json_multi_params_sets ], indirect=True)
+    def test_multi_params_sets(self, load_json):
+        combined_json = multiplex.load_param_sets(load_json)
+        short_json = json.dumps(combined_json, sort_keys=True, indent=None).replace("\n", "")
+        short_json = short_json.replace(" ", "")
+        expected_json = self.json_multi_sets_expected.replace("\n", "")
+        expected_json = expected_json.replace(" ", "")
+
+        assert short_json == expected_json
+
+    """Test if multiplex_sets handles multiple sets of multi-value params"""
+    @pytest.mark.parametrize("load_json", [ json_multi_sets_expected ], indirect=True)
+    def test_multiplex_multi_sets(self, load_json):
+        global validation_dict
+        multiplexed_json = multiplex.multiplex_sets(load_json)
+        short_json = json.dumps(multiplexed_json, sort_keys=True, indent=None).replace("\n", "")
+        expected_json = self.json_multiplexed_multi_sets_expected.replace("\n", "")
+        short_json = short_json.replace(" ", "")
+        expected_json = expected_json.replace(" ", "")
+
+        assert short_json == expected_json
+
+    """Test if convert_vals replaces vals with val on multiplexed json"""
+    @pytest.mark.parametrize("load_json", [ json_multiplexed_multi_sets_expected ], indirect=True)
+    def test_convert_vals(self, load_json):
+        finalized_json = multiplex.convert_vals(load_json)
+        for sets in finalized_json:
+            for set in sets:
+                assert 'vals' not in set
+                assert 'val' in set


### PR DESCRIPTION
When converting vals to val, the 2nd included
common-params object is modified. A deepcopy is
required to keep original object unchanged.

This fix has been done before in this commit[1]
But the bug was reintroduced in this other commit [2]

A couple tests have been added to cover this case.

[1] beb27aadf983c499d4d1f1b9070c683bf37fd3c4
[2] 9f7fbdf8b24e95a3e76389b35ef5e92cf49450f3