### PR TITLE
Fix bugs plus code refactoring

### DIFF
--- a/tests/test-requirements.py
+++ b/tests/test-requirements.py
@@ -2,8 +2,8 @@
 
 import pytest
 import json
-import multiplex
 import re
+import multiplex
 
 class TestRequirements:
 
@@ -34,18 +34,17 @@ class TestRequirements:
     """Test if validation dict is successfully created"""
     @pytest.mark.parametrize("load_req", [ requirements_json ], indirect=True)
     def test_create_validation_dict(self, load_req):
-        val_dict = multiplex.create_validation_dict(load_req)
+        multiplex.create_validation_dict(load_req)
 
-        assert val_dict is not None
-        assert 'bs' in val_dict.keys()
+        assert multiplex.validation_dict is not {}
+        assert 'bs' in multiplex.validation_dict.keys()
 
-    """Test if validation dict has empty presets"""
+    """Test if validation dict has empty presets (which is ok)"""
     @pytest.mark.parametrize("load_req", [ validation_json_fail ], indirect=True)
     def test_empty_presets(self, load_req):
-        val_dict = multiplex.create_validation_dict(load_req)
+        multiplex.create_validation_dict(load_req)
 
-        assert val_dict is not None
-        assert 'presets' in load_req
+        assert multiplex.validation_dict is not {}
         assert load_req['presets'] == {}
 
     """Test invalid vals"""


### PR DESCRIPTION
A couple issues have been fixed in this change:

Single param now produces correct output and validation
Single val now produces correct output and validation
Disabled params no longer show up in the output
Two or more includes of common-params are now possible
N:N combination of params is now producing correct output

This change also include some code refactoring:

Moved global vars to outside of main() so we don't need to
mock them or call main to test a function.
Created sanitize function to check for default roles and disabled
params outside of multiplex_set.
multiplex_set iterates over the set object adding each param val
to a combined list that results in a cartesian product. A copy of
the entire set is made for each combination. At the end, values
are updated in the update_vals function with the cartesian product
containing an array of tuples.