### PR TITLE
only run ci jobs on pull requests, not pushes

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -2,8 +2,6 @@ name: crucible-ci
 
 on:
   # run on push or pull request events for the master branch only
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -4,8 +4,6 @@ name: unittest
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
- this avoids unneccessary runs of the ci