### PR TITLE
update the GitHub upload-artifact action to v4 (from v3)

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -45,7 +45,7 @@ jobs:
           pytest -v --html=report.html --self-contained-html multiplex.py tests/*.py
 
       - name: Upload html report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: report
           path: report.html


### PR DESCRIPTION
- see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/