### PR TITLE
docs: add description fields to multiplex schemas

### DIFF
--- a/JSON/req-schema.json
+++ b/JSON/req-schema.json
@@ -1,13 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/perftool-incubator/multiplex/master/req-schema.json",
+    "title": "Multiplex Requirements Schema",
+    "description": "Schema for multiplex requirements files (multiplex.json) that define parameter presets, validation rules, and unit conversions for a benchmark.  Requirements files constrain and enrich the parameter expansion process.",
 
     "type": "object",
     "properties": {
         "presets": {
+            "description": "A dictionary of named parameter presets.  Each preset is an array of parameter definitions that can be referenced by sets via 'include-preset'.  Special preset names 'defaults' and 'essentials' are applied automatically.",
             "type": "object",
             "patternProperties": {
                 "[a-zA-Z0-9_-]*$": {
+                    "description": "An array of parameter definitions belonging to this named preset.",
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
@@ -19,6 +23,7 @@
             "additionalProperties": false
         },
         "validations": {
+            "description": "A dictionary of validation rules that constrain parameter values.  Each validation specifies which arguments it applies to and what values or patterns are acceptable.",
             "type": "object",
             "patternProperties": {
                 "[A-Za-z0-9_-]*$": {
@@ -28,6 +33,7 @@
             "additionalProperties": false
         },
         "units": {
+            "description": "A dictionary of unit conversion definitions.  Each entry maps a parameter to its unit system, enabling automatic conversion between units (e.g., KB to MB).",
             "type": "object",
             "patternProperties": {
                 "[A-Za-z0-9_-]*$": {
@@ -41,30 +47,37 @@
     "additionalProperties": false,
     "definitions": {
         "mv_param": {
+            "description": "A multivariate parameter definition used within presets.",
             "type": "object",
             "properties": {
                 "arg": {
+                    "description": "The parameter argument name.",
                     "type": "string",
                     "minLength": 1
                 },
                 "vals": {
+                    "description": "An array of values for this parameter.",
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
+                        "description": "A parameter value.",
                         "type": "string",
                         "minLength": 1
                     }
                 },
                 "role": {
+                    "description": "The engine role this parameter applies to.",
                     "type": "string",
                     "enum": ["client", "server", "all"]
                 },
                 "id": {
+                    "description": "An optional numeric identifier for this parameter.",
                     "type": "string",
                     "pattern": "^[1-9][0-9]*$"
                 },
                 "enabled": {
+                    "description": "Controls whether this parameter is active.",
                     "type": "string",
                     "enum": ["yes", "no"]
                 }
@@ -76,48 +89,60 @@
             "additionalProperties": false
         },
         "validation_obj": {
+            "description": "A validation rule that constrains the allowed values for one or more parameter arguments.",
             "type": "object",
             "properties": {
                 "args": {
+                    "description": "An array of parameter argument names that this validation applies to.",
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
+                        "description": "A parameter argument name.",
                         "type": "string",
                         "minLength": 1
                     }
                 },
                 "vals": {
+                    "description": "The allowed values, specified as either an array of explicit values or a single regex pattern string.",
                     "anyOf": [
                         {
+                            "description": "An array of explicitly allowed values.",
                             "type": "array",
                             "minItems": 1,
                             "uniqueItems": true,
                             "items": {
+                                "description": "An allowed value.",
                                 "type": "string",
                                 "minLength": 1
                                 }
                         },
                         {
+                            "description": "A regex pattern that parameter values must match.",
                             "type": "string",
                             "minLength": 1
                         }
                     ]
                 },
                 "description": {
+                    "description": "A human-readable description of what this validation rule enforces, shown in error messages when validation fails.",
                     "type": "string",
                     "minLength": 1
                 },
                 "convert": {
+                    "description": "A unit key from the 'units' section, indicating that values should be converted to a canonical unit before validation.",
                     "type": "string"
                 },
                 "transform": {
+                    "description": "A regex search-and-replace transformation applied to parameter values before validation.",
                     "type": "object",
                     "properties": {
                         "search": {
+                            "description": "The regex pattern to search for in the parameter value.",
                             "type": "string"
                         },
                          "replace": {
+                            "description": "The replacement string for matched patterns.",
                             "type": "string"
                         }
                     },
@@ -132,14 +157,17 @@
             "additionalProperties": false
         },
         "unit_obj": {
+            "description": "A unit conversion definition mapping unit names to their conversion factors relative to a base unit.",
             "type": "object",
             "minProperties": 1,
             "patternProperties": {
                 "[A-Za-z0-9_-]*$": {
+                    "description": "A unit category containing conversion factors.",
                     "type": "object",
                     "minProperties": 1,
                     "patternProperties": {
                         "[A-Za-z0-9_-]*$": {
+                            "description": "A conversion factor from this unit to the base unit.",
                             "type": "string"
                         }
                     },

--- a/JSON/schema.json
+++ b/JSON/schema.json
@@ -1,13 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/perftool-incubator/multiplex/master/schema.json",
+    "title": "Multiplex Input Schema",
+    "description": "Schema for multivariate parameter input files (mv-params).  Defines global-options (reusable named parameter groups) and sets (test configurations that reference global-options and add their own parameters).  Each set is independently expanded via Cartesian product to generate the iteration matrix.",
 
     "type": "object",
     "properties": {
         "schema": {
+            "description": "Schema version information.",
             "type": "object",
             "properties": {
                 "version": {
+                    "description": "The schema version this file conforms to.",
                     "type": "string",
                     "enum": [
                         "2021.12.02"
@@ -16,17 +20,21 @@
             }
         },
         "global-options": {
+            "description": "An array of named parameter groups that can be referenced by sets via the 'include' field.  Global-options provide reusable parameter definitions to avoid duplication across sets.",
             "type": "array",
             "minItems": 0,
             "uniqueItems": true,
             "items": {
+                "description": "A named parameter group containing one or more multivariate parameters.",
                 "type": "object",
                 "properties": {
                     "name": {
+                        "description": "The name of this parameter group, used by sets in their 'include' field to reference these parameters.",
                         "type": "string",
                         "minLength": 1
                     },
                     "params": {
+                        "description": "An array of multivariate parameters belonging to this named group.",
                         "type": "array",
                         "minItems": 1,
                         "uniqueItems": true,
@@ -43,36 +51,44 @@
             }
         },
         "sets": {
+            "description": "An array of parameter sets, each defining a test configuration.  Each set can include parameters from global-options and define its own parameters.  Sets are independently expanded via Cartesian product.",
             "type": "array",
             "minItems": 0,
             "uniqueItems": true,
             "items": {
+                "description": "A parameter set that defines one test configuration.  Parameters inherited via 'include' are combined with the set's own parameters before Cartesian expansion.",
                 "type": "object",
                 "minItems": 1,
                 "uniqeueItems": true,
                 "properties": {
                     "include": {
+                        "description": "References to global-options groups whose parameters should be inherited by this set.  Can be a single group name or an array of group names.",
                         "anyOf": [
                             {
+                                "description": "An array of global-options group names to include.",
                                 "type": "array",
                                 "minItems": 1,
                                 "uniqueItems": true,
                                 "items": {
+                                    "description": "A global-options group name.",
                                     "type": "string",
                                     "minLength": 1
                                     }
                             },
                             {
+                                "description": "A single global-options group name to include.",
                                 "type": "string",
                                 "minLength": 1
                             }
                         ]
                     },
                     "include-preset": {
+                        "description": "The name of a preset from the requirements file to include in this set.  Presets provide default parameter values defined by the benchmark.",
                         "type": "string",
                         "minLength": 1
                     },
                     "params": {
+                        "description": "An array of multivariate parameters specific to this set, combined with any included global-options parameters.",
                         "type": "array",
                         "uniqueItems": true,
                         "items": {
@@ -80,6 +96,7 @@
                         }
                     },
                     "enabled": {
+                        "description": "Controls whether this set is included in the expansion.  Defaults to 'yes' if not specified.",
                         "type": "string",
                         "enum": ["yes", "no"]
                     }
@@ -91,38 +108,47 @@
     "additionalProperties": false,
     "definitions": {
         "mv_param": {
+            "description": "A multivariate parameter definition with an argument name and one or more values.  Multiple values in 'vals' create iterations via Cartesian product with other multi-valued parameters.",
             "type": "object",
             "properties": {
                 "arg": {
+                    "description": "The parameter argument name, passed as --arg to the benchmark engine.",
                     "type": "string",
                     "minLength": 1
                 },
                 "vals": {
+                    "description": "An array of values for this parameter.  Multiple values multiply with other multi-valued parameters to create the iteration matrix.",
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
+                        "description": "A parameter value.",
                         "type": "string",
                         "minLength": 1
                     }
                 },
                 "role": {
+                    "description": "The engine role this parameter applies to.  'client' and 'server' restrict the parameter to that role, while 'all' (default) applies it to every engine.",
                     "type": "string",
                     "enum": ["client", "server", "all"]
                 },
                 "id": {
+                    "description": "An optional numeric identifier for this parameter, used for tracking across the expansion pipeline.",
                     "type": "string",
                     "pattern": "^[1-9][0-9]*$"
                 },
                 "ids": {
+                    "description": "An optional array of engine ID ranges that this parameter applies to, restricting it to specific engines.",
                     "type": "array",
                     "minItems": 1,
                     "items": {
+                        "description": "An engine ID or ID range (e.g., '1', '1-4').",
                         "type": "string",
                         "pattern": "^[1-9][0-9]*(-[1-9][0-9]*)?$"
                     }
                 },
                 "enabled": {
+                    "description": "Controls whether this parameter is included in the expansion.  Defaults to 'yes' if not specified.",
                     "type": "string",
                     "enum": ["yes", "no"]
                 }


### PR DESCRIPTION
## Summary
- Add title, description, and per-property description fields to `JSON/schema.json` (mv-params input schema)
- Add title, description, and per-property description fields to `JSON/req-schema.json` (requirements schema)
- Part of a cross-repo effort to add descriptions to all JSON schemas ([PERFNFV-319](https://redhat.atlassian.net/browse/PERFNFV-319))

## Test plan
- [ ] `python3 -c "import json; json.load(open('JSON/schema.json'))"` passes
- [ ] `python3 -c "import json; json.load(open('JSON/req-schema.json'))"` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)